### PR TITLE
Fixes #21515 - update bundler before running travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ rvm:
   - 2.2.0
   - 2.3.0
 sudo: false
+before_install:
+  - gem update bundler


### PR DESCRIPTION
Bundler 1.8.6 had an issue:

    NoMethodError: undefined method `spec' for nil:NilClass