### PR TITLE
Relax dependency version

### DIFF
--- a/hammer_cli_foreman_remote_execution.gemspec
+++ b/hammer_cli_foreman_remote_execution.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
   s.test_files =       `git ls-files test`.split("\n")
   s.extra_rdoc_files = `git ls-files doc`.split("\n") + Dir['README*', 'LICENSE']
 
-  s.add_dependency 'hammer_cli_foreman', '>= 0.1.3', '< 1.0.0'
+  s.add_dependency 'hammer_cli_foreman', '>= 0.1.3'
   s.add_dependency 'hammer_cli_foreman_tasks', '~> 0.0.3'
 end


### PR DESCRIPTION
Upstream core moved to 2.0.0 version and this prevents from installing.