### PR TITLE
Fixes #29867 - Show job status for each host on JobInvocation detail

### DIFF
--- a/lib/hammer_cli_foreman_remote_execution/job_invocation.rb
+++ b/lib/hammer_cli_foreman_remote_execution/job_invocation.rb
@@ -30,7 +30,6 @@ module HammerCLIForemanRemoteExecution
 
     class InfoCommand < HammerCLIForeman::InfoCommand
       extend WithoutNameOption
-      option '--host-status', :flag, N_('Show job status for the hosts.')
 
       output ListCommand.output_definition do
         field :job_category, _('Job Category')

--- a/lib/hammer_cli_foreman_remote_execution/job_invocation.rb
+++ b/lib/hammer_cli_foreman_remote_execution/job_invocation.rb
@@ -30,6 +30,8 @@ module HammerCLIForemanRemoteExecution
 
     class InfoCommand < HammerCLIForeman::InfoCommand
       extend WithoutNameOption
+      option '--host-status', :flag, N_('Show job status for the hosts.')
+
       output ListCommand.output_definition do
         field :job_category, _('Job Category')
         field :mode, _('Mode')
@@ -187,9 +189,14 @@ module HammerCLIForemanRemoteExecution
     def self.extend_data(invocation)
       if (targeting = invocation['targeting']) && invocation['targeting']['hosts']
         invocation['randomized_ordering'] = targeting['randomized_ordering']
-        if (hosts = targeting['hosts'])
-          invocation['hosts'] = "\n" + hosts.map { |host| " - #{host['name']}" }.join("\n")
+
+        hosts = targeting['hosts'].map do |host|
+          host_item = " - #{host['name']}"
+          host_item << ", Job status: #{host['job_status']}" if host['job_status']
+          host_item
         end
+
+        invocation['hosts'] = "\n" + hosts.join("\n")
       end
 
       if invocation['recurrence']


### PR DESCRIPTION
Requires: https://github.com/theforeman/foreman_remote_execution/pull/494

**Before**
```
hammer job-invocation info --id 881
ID:                  881
Description:         Run sleep 160
Status:              succeeded
Success:             11
Failed:              0
Pending:             0
Total:               11
Start:               2020-05-18 12:43:11 UTC
Randomized ordering: false
Job Category:        Commands
Hosts:               
 - zzzz100.example.com
 - zzzz101.example.com
 - zzzz102.example.com
 - zzzz103.example.com
```

**Now**
```
hammer job-invocation info --id 881 --host-status
ID:                  881
Description:         Run sleep 160
Status:              succeeded
Success:             11
Failed:              0
Pending:             0
Total:               11
Start:               2020-05-18 12:43:11 UTC
Randomized ordering: false
Job Category:        Commands
Hosts:               
 - zzzz100.example.com, Job status: success
 - zzzz101.example.com, Job status: success
 - zzzz102.example.com, Job status: success
 - zzzz103.example.com, Job status: success
```