### PR TITLE
Fixes #29867 - '--show-host-status' as a flag, not boolean argument

### DIFF
--- a/lib/hammer_cli_foreman_remote_execution/job_invocation.rb
+++ b/lib/hammer_cli_foreman_remote_execution/job_invocation.rb
@@ -39,7 +39,7 @@ module HammerCLIForemanRemoteExecution
       extend WithoutNameOption
       include BaseOutput
       option '--show-inputs', :flag, _('Show the complete input of the job')
-      option '--show-host-status', :flag, _('Show job status for the hosts.')
+      option '--show-host-status', :flag, _('Show job status for the hosts')
 
       extend_output_definition do |definition|
         definition.insert(:before, :total) do

--- a/lib/hammer_cli_foreman_remote_execution/job_invocation.rb
+++ b/lib/hammer_cli_foreman_remote_execution/job_invocation.rb
@@ -39,6 +39,7 @@ module HammerCLIForemanRemoteExecution
       extend WithoutNameOption
       include BaseOutput
       option '--show-inputs', :flag, _('Show the complete input of the job')
+      option '--show-host-status', :flag, _('Show job status for the hosts.')
 
       extend_output_definition do |definition|
         definition.insert(:before, :total) do
@@ -79,6 +80,13 @@ module HammerCLIForemanRemoteExecution
 
       build_options do |o|
         o.expand(:none)
+        o.without(:host_status)
+      end
+
+      def request_params
+        params = super
+        params[:host_status] = true if option_show_host_status?
+        params
       end
     end
 

--- a/lib/hammer_cli_foreman_remote_execution/version.rb
+++ b/lib/hammer_cli_foreman_remote_execution/version.rb
@@ -1,5 +1,5 @@
 module HammerCLIForemanRemoteExecution
   def self.version
-    @version ||= Gem::Version.new '0.2.0'
+    @version ||= Gem::Version.new '0.2.1'
   end
 end


### PR DESCRIPTION
Following suggestion from https://bugzilla.redhat.com/show_bug.cgi?id=1825458#c7 comment

Before:
```
hammer job-invocation info --id 15 --host-status true/1
```

Now:
```
hammer job-invocation info --id 15 --show-host-status
```