### PR TITLE
Fixes #33007 - Do not offer taxonomy options for j-i list

### DIFF
--- a/lib/hammer_cli_foreman_remote_execution/job_invocation.rb
+++ b/lib/hammer_cli_foreman_remote_execution/job_invocation.rb
@@ -32,7 +32,7 @@ module HammerCLIForemanRemoteExecution
         JobInvocation.extend_data(invocation)
       end
 
-      build_options
+      build_options :expand => { :except => %i[organizations locations] }, :without => %i[organization_id location_id]
     end
 
     class InfoCommand < HammerCLIForeman::InfoCommand


### PR DESCRIPTION
Job invocations are not scoped to organizations and locations.