### PR TITLE
Fixes #34404 - Properly mark interfaces as execution

### DIFF
--- a/lib/hammer_cli_foreman_remote_execution/interface_extensions.rb
+++ b/lib/hammer_cli_foreman_remote_execution/interface_extensions.rb
@@ -25,6 +25,40 @@ module HammerCLIForemanRemoteExecution
     end
   end
 
+  module MandatoryInterfacesExtensions
+    def mandatory_interfaces(host_id, nic_id)
+      attributes = super
+      return attributes if option_execution.nil?
+
+      nics = get_interfaces(host_id)['results']
+      current = nics.find { |nic| nic['id'] == nic_id.to_i }
+      # We don't need to do anything if the interface we're trying to change is
+      # already in its desired state
+      return attributes if current['execution'] == !!option_execution
+
+      # There needs to be exactly one interface marked as execution
+      # There should be a hook on Foreman's side to mark the primary interface
+      # as execution if no interface is marked as such, but it doesn't seem to
+      # work reliably
+      execution_id = if option_execution
+                       nic_id.to_i
+                     else
+                       # If there's no interface marked as primary from super,
+                       # let's pick the primary from server's data
+                       primary = attributes.find { |nic| nic['primary'] } || nics.find { |nic| nic['primary'] }
+                       primary['id']
+                     end
+
+      nics.map do |nic|
+        base = attributes.find { |attr| attr['id'] == nic['id'] } || { 'id' => nic['id'] }
+        base['execution'] = nic['id'] == execution_id
+        base
+      end
+    end
+  end
+
+  ::HammerCLIForeman::Interface::UpdateCommand.prepend MandatoryInterfacesExtensions
+  ::HammerCLIForeman::Interface::CreateCommand.prepend MandatoryInterfacesExtensions
   ::HammerCLIForeman::Interface.singleton_class.prepend InterfaceExtensionsList
   ::HammerCLIForeman::Interface::InfoCommand.extend_with(InterfaceExtensionsInfo.new)
 end

--- a/test/unit/mandatory_interfaces_extensions_test.rb
+++ b/test/unit/mandatory_interfaces_extensions_test.rb
@@ -1,0 +1,73 @@
+ENV['TEST_API_VERSION'] = '1.17'
+require File.join(Gem.loaded_specs['hammer_cli_foreman'].full_gem_path, 'test/unit/test_helper')
+# require File.join(Gem.loaded_specs['hammer_cli_foreman'].full_gem_path, 'test/unit/apipie_resource_mock')
+require 'hammer_cli_foreman_remote_execution'
+
+describe HammerCLIForemanRemoteExecution::MandatoryInterfacesExtensions do
+  context '#mandatory_interfaces' do
+
+    class CustomCommand
+      prepend HammerCLIForemanRemoteExecution::MandatoryInterfacesExtensions
+
+      attr_accessor :mandatory_interfaces_data
+      def mandatory_interfaces(host_id, nic_id)
+        mandatory_interfaces_data
+      end
+    end
+
+    let(:command) { CustomCommand.new }
+
+    it 'does nothing if execution interface is not being changed' do
+      command.mandatory_interfaces_data = 'unchanged'
+      command.expects(:option_execution)
+      command.mandatory_interfaces(1, 2).must_equal 'unchanged'
+    end
+
+    it 'does nothing when setting execution flag on execution interface' do
+      command.mandatory_interfaces_data = 'unchanged'
+      command.expects(:option_execution).twice.returns(true)
+      command.expects(:get_interfaces).returns({ 'results' => [{'id' => 2, 'execution' => true}]})
+      command.mandatory_interfaces(1, 2).must_equal 'unchanged'
+    end
+
+    it 'does nothing when unsetting execution flag on non-execution interface' do
+      command.mandatory_interfaces_data = 'unchanged'
+      command.expects(:option_execution).twice.returns(false)
+      command.expects(:get_interfaces).returns({ 'results' => [{'id' => 2, 'execution' => false}]})
+      command.mandatory_interfaces(1, 2).must_equal 'unchanged'
+    end
+
+    it 'unsets all other interfaces as execution' do
+      data = [{'id' => 2, 'primary' => true}]
+      command.mandatory_interfaces_data = data
+      command.expects(:option_execution).times(3).returns(true)
+      command.expects(:get_interfaces).returns({ 'results' => [{'id' => 2, 'execution' => false}, {'id' => 3, 'execution' => false}]})
+      command.mandatory_interfaces(1, 3).must_equal [
+        {'id' => 2, 'execution' => false, 'primary' => true},
+        {'id' => 3, 'execution' => true}
+      ]
+    end
+
+    it 'marks primary interface as execution when unsetting' do
+      data = [{'id' => 2, 'primary' => true}]
+      command.mandatory_interfaces_data = data
+      command.expects(:option_execution).times(3).returns(false)
+      command.expects(:get_interfaces).returns({ 'results' => [{'id' => 2, 'execution' => false}, {'id' => 3, 'execution' => true}]})
+      command.mandatory_interfaces(1, 3).must_equal [
+        {'id' => 2, 'execution' => true, 'primary' => true},
+        {'id' => 3, 'execution' => false}
+      ]
+    end
+
+    it 'marks primary interface as execution when unsetting' do
+      data = []
+      command.mandatory_interfaces_data = data
+      command.expects(:option_execution).times(3).returns(false)
+      command.expects(:get_interfaces).returns({ 'results' => [{'id' => 2, 'execution' => false, 'primary' => true}, {'id' => 3, 'execution' => true}]})
+      command.mandatory_interfaces(1, 3).must_equal [
+        {'id' => 2, 'execution' => true},
+        {'id' => 3, 'execution' => false}
+      ]
+    end
+  end
+end


### PR DESCRIPTION
When an interface is being marked as execution, we explicitly mark all other
interfaces as non-execution. Inversely, when an interface is being unmarked as
execution, we explicitly mark the primary interfaces as execution.