### PR TITLE
Expose cloned from id in job template info command

### DIFF
--- a/lib/hammer_cli_foreman_remote_execution/job_template.rb
+++ b/lib/hammer_cli_foreman_remote_execution/job_template.rb
@@ -23,6 +23,7 @@ module HammerCLIForemanRemoteExecution
     class InfoCommand < HammerCLIForeman::InfoCommand
       output ListCommand.output_definition do
         field :description, _('Description'), Fields::Text
+        field :cloned_from_id, _("Cloned from id"), nil, :hide_blank => true
         field :template_inputs, _('Inputs')
         HammerCLIForeman::References.taxonomies(self)
       end


### PR DESCRIPTION
Expose `cloned_from_id` in job template info command if exists.