### PR TITLE
Relax hammer_cli_foreman dependency to allow 5.x

### DIFF
--- a/hammer_cli_foreman_remote_execution.gemspec
+++ b/hammer_cli_foreman_remote_execution.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files =       Dir["test/**/*"]
   s.extra_rdoc_files = Dir['README.md', 'LICENSE']
 
-  s.add_dependency 'hammer_cli_foreman', '>= 0.1.3', '< 4.0.0'
+  s.add_dependency 'hammer_cli_foreman', '>= 0.1.3', '< 6.0.0'
   s.add_dependency 'hammer_cli_foreman_tasks', '~> 0.0.3'
 
   s.required_ruby_version = '>= 2.7', '< 4'


### PR DESCRIPTION
## Summary
- Relax the hammer_cli_foreman version constraint to < 6.0.0 to allow compatibility with the upcoming 5.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)