### PR TITLE
Fixes #39411 - Display locked field as yes/no in job template info

### DIFF
--- a/lib/hammer_cli_foreman_remote_execution/job_template.rb
+++ b/lib/hammer_cli_foreman_remote_execution/job_template.rb
@@ -25,7 +25,7 @@ module HammerCLIForemanRemoteExecution
         field :description, _('Description'), Fields::Text
         field :cloned_from_id, _("Cloned from id"), nil, :hide_blank => true
         field :template_inputs, _('Inputs')
-        field :locked, _('Locked')
+        field :locked, _('Locked'), Fields::Boolean
         HammerCLIForeman::References.taxonomies(self)
       end
 

--- a/test/unit/job_template_test.rb
+++ b/test/unit/job_template_test.rb
@@ -40,6 +40,14 @@ describe HammerCLIForemanRemoteExecution::JobTemplate do
       with_params ['--id=1'] do
         it_should_print_columns ['ID', 'Name', 'Job Category', 'Provider', 'Type', 'Locked']
       end
+
+      it 'should format locked field as "no"' do
+        cmd.stubs(:context).returns(ctx.update(:adapter => :base))
+        out, _err = capture_io do
+          cmd.run(['--id=1'])
+        end
+        _(out).must_match(/Locked:\s+no/)
+      end
     end
   end
 


### PR DESCRIPTION
The `locked` field in `job-template info` was missing the `Fields::Boolean` type annotation, causing it to display raw `true`/`false` values instead of `yes`/`no` like other template types (e.g. partition tables).

Redmine: https://projects.theforeman.org/issues/39411